### PR TITLE
Dot not pass delegate to ServerCertificateCustomValidationCallback by default

### DIFF
--- a/Vostok.ClusterClient.Tests/Vostok.ClusterClient.Tests.csproj
+++ b/Vostok.ClusterClient.Tests/Vostok.ClusterClient.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Vostok.Core" Version="1.0.0-pre000179" />
+    <PackageReference Include="Vostok.Core" Version="1.0.0-pre000181" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />

--- a/Vostok.ClusterClient.Transport.Http/Vostok.ClusterClient.Transport.Http.csproj
+++ b/Vostok.ClusterClient.Transport.Http/Vostok.ClusterClient.Transport.Http.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netstandard2.0;net462</TargetFrameworks>
     <RootNamespace>Vostok.Clusterclient.Transport.Http</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -9,6 +9,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Vostok.ClusterClient\Vostok.ClusterClient.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+     <Compile Remove="net46\**" />
+     <None Include="net46\**" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
      <Compile Remove="net46\**" />

--- a/Vostok.ClusterClient.Transport.Http/Vostok.ClusterClient.Transport.Http.csproj
+++ b/Vostok.ClusterClient.Transport.Http/Vostok.ClusterClient.Transport.Http.csproj
@@ -1,18 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <RootNamespace>Vostok.Clusterclient.Transport.Http</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Vostok.Core" Version="1.0.0-pre000179" />
+    <PackageReference Include="Vostok.Core" Version="1.0.0-pre000181" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Vostok.ClusterClient\Vostok.ClusterClient.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-     <Compile Remove="net46\**" />
-     <None Include="net46\**" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
      <Compile Remove="net46\**" />

--- a/Vostok.ClusterClient.Transport.Http/netstandard/VostokHttpTransport_Standard.cs
+++ b/Vostok.ClusterClient.Transport.Http/netstandard/VostokHttpTransport_Standard.cs
@@ -99,6 +99,14 @@ namespace Vostok.Clusterclient.Transport.Http
                 ServerCertificateCustomValidationCallback = null
             };
 
+            // (alexkir, 13.10.2017) we can safely pass callbacks only on Windows; see https://github.com/dotnet/corefx/pull/19908
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT ||
+                Environment.OSVersion.Platform == PlatformID.Win32S ||
+                Environment.OSVersion.Platform == PlatformID.Win32Windows ||
+                Environment.OSVersion.Platform == PlatformID.WinCE)
+                // TODO(alexkir, 13.10.2017): decide if this is a good optimization practice to always ignore SSL cert validity
+                handler.ServerCertificateCustomValidationCallback = (_, __, ___, ____) => true;
+
             return handler;
         }
 

--- a/Vostok.ClusterClient.Transport.Http/netstandard/VostokHttpTransport_Standard.cs
+++ b/Vostok.ClusterClient.Transport.Http/netstandard/VostokHttpTransport_Standard.cs
@@ -96,7 +96,7 @@ namespace Vostok.Clusterclient.Transport.Http
                 UseDefaultCredentials = false,
                 UseCookies = false,
                 UseProxy = false,
-                ServerCertificateCustomValidationCallback = (_, __, ___, ____) => true
+                ServerCertificateCustomValidationCallback = null
             };
 
             return handler;

--- a/Vostok.ClusterClient/Vostok.ClusterClient.csproj
+++ b/Vostok.ClusterClient/Vostok.ClusterClient.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Vostok.Core" Version="1.0.0-pre000179" />
+    <PackageReference Include="Vostok.Core" Version="1.0.0-pre000181" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Custom delegates are broken on some *nix systems. See: https://github.com/dotnet/corefx/pull/19908

Instead of adding something `Dangerous` to our libraries, we should just check the certificates.